### PR TITLE
Allow users to specify available fields for the outputting spreadsheet

### DIFF
--- a/HSM/README.MD
+++ b/HSM/README.MD
@@ -1,14 +1,12 @@
 # HSM
-`app.py` provides a command line interface for the Ham-Spam Machine (HSM). Currently, it only fethces and classifies responses to the **site-wide version** of the survey. It uses a local instance of a postgreSQL database, although it does allow the user to validate comment predictions in excel while the script is sleeping. 
+`app.py` provides a command line interface for the Ham-Spam Machine (HSM). Currently, it only fetches and classifies responses to the **site-wide version** of the survey. It uses a local instance of a postgreSQL database, although it does allow the user to validate comment predictions in excel while the script is sleeping.
 
 ## Getting Started
 
 ### Step 1: Install & Configure PostgresSQL
 
 #### Step 1.1:  Install Homebrew
-You don't have to install homebrew in order to install postgres. But it's by far the easiest approach.
-
->`$ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
+You don't have to install homebrew in order to install postgres. But it's by far the easiest approach.  To go to [brew's homepage](https://brew.sh/) to install.
 
 #### Step 1.2: Check Homebrew
 Before you install anything with Homebrew, you should always make sure it's up to date and that it's healthy:
@@ -17,10 +15,10 @@ Before you install anything with Homebrew, you should always make sure it's up t
 
 ### Step 2: Clone the Repository
 Navigate to where you'd like to clone the repo. Then clone it:
->`$ git clone https://github.com/18F/10x-qualitative-data.git`
+>`$ git clone https://github.com/18F/10x-MLaaS.git`
 
 Now `cd` into the repository you've just cloned:
->`$ cd 10x-qualitative-data`
+>`$ cd 10x-MLaaS`
 
 
 ### Run with Docker & Docker Compose
@@ -45,12 +43,13 @@ Modify Qualtrics Env variables in `.env`:
 
 
 #### Step 3 Build & Run!  
-    
+
+This will bring up the containers:
 >```
 >$ docker-compose up
 >```
   
-(In another terminal)
+(In another terminal).  This will run the application within `mlaas-web`:
 >```
 >$ docker exec --user hsm --workdir /home/hsm -it mlaas-web /bin/bash -c "python ~/HSM/app.py"
 >```

--- a/HSM/README.MD
+++ b/HSM/README.MD
@@ -50,6 +50,8 @@ Now that you're environment is set up, you can use `app.py` as a CLI tool. Here'
  - Downloads data from the Qualtrics API. 
     - If it's your first time running this, it'll download all responses to-date. Otherwise it'll check the database for the last response and then only fetch new responses.
  - Feeds concatenated survey comments to a pre-trained `sklearn` classifer to predict spam (1) or ham (0)
+ - User can make changes to what fields to return as part of the outputting spreadsheet in utils/config.py
+   - Keep in mind that you should make sure `SPAM` and `Comment Concatentated` fields should be included for training purpose later.
  - Sleeps to give you time to review the predictions in  `HSM/model/results/ClassificationResults.xlsx`
     - When reviewing the results, the prediction is in the `SPAM` column (0 = ham and 1 = spam). 
     - Make your changes inplace, overwriting the prediction if you disagree.

--- a/HSM/README.MD
+++ b/HSM/README.MD
@@ -3,17 +3,7 @@
 
 ## Getting Started
 
-### Step 1: Install & Configure PostgresSQL
-
-#### Step 1.1:  Install Homebrew
-You don't have to install homebrew in order to install postgres. But it's by far the easiest approach.  To go to [brew's homepage](https://brew.sh/) to install.
-
-#### Step 1.2: Check Homebrew
-Before you install anything with Homebrew, you should always make sure it's up to date and that it's healthy:
->`$ brew update`<br>
->`$ brew doctor`
-
-### Step 2: Clone the Repository
+### Step 1: Clone the Repository
 Navigate to where you'd like to clone the repo. Then clone it:
 >`$ git clone https://github.com/18F/10x-MLaaS.git`
 
@@ -21,13 +11,13 @@ Now `cd` into the repository you've just cloned:
 >`$ cd 10x-MLaaS`
 
 
-### Run with Docker & Docker Compose
+### Step 2: Run with Docker & Docker Compose
 
-#### Step 1 Install Docker
+#### Step a: Install Docker (if you do not have docker already)
 
 https://docs.docker.com/compose/install/
 
-#### Step 2 Configure Environment Variables
+#### Step b: Configure Environment Variables
 
 >```
 >$ cp sample.env .env

--- a/HSM/utils/config.py
+++ b/HSM/utils/config.py
@@ -15,3 +15,38 @@ apiToken = os.environ['QUALTRICS_API_TOKEN']
 survey_id = os.environ['QUALTRICS_SW_SURVEY_ID']
 qualtrics_sitewide_creds = {"apiToken": apiToken,
                             "surveyId": survey_id}
+
+# SPREADSHEET SETTINGS
+FIELDS = [
+    "ResponseID",
+    "pageType",
+    "StartDate",
+    "EndDate",
+    "Country",
+    "State",
+    "UPVC",
+    "TVPC",
+    "Site_Referrer",
+    "PR_URL",
+    "CP_URL",
+    "Asset_Click",
+    "Q1",
+    "Q4",
+    "Comments Concatenated",
+    "SPAM",
+    "Q2",
+    "Q3",
+    "Q5",
+    "Q6",
+    "Q7",
+    "Q8",
+    "Q9",
+    "DeviceType",
+    "Referer",
+    "History",
+    "Browser Metadata Q_1_TEXT",
+    "Browser Metadata Q_2_TEXT",
+    "Browser Metadata Q_3_TEXT",
+    "Browser Metadata Q_4_TEXT",
+    # "Duration (in seconds)",
+]

--- a/HSM/utils/qualtrics.py
+++ b/HSM/utils/qualtrics.py
@@ -64,17 +64,17 @@ class QualtricsApi:
                   }
         # Step 1: Creating Data Export
         downloadRequestUrl = baseUrl
+        downloadRequestPayload = {
+                                    "format": self.fileFormat,
+                                    "surveyId": self.surveyId,
+                                    "useLabels": True
+                                 }
         # Include lastResponseId in payload if provided during init
         if self.lastResponseId:
-            downloadRequestPayload = '{"format":"' + self.fileFormat + \
-                                     '","surveyId":"' + self.surveyId + \
-                                     '","lastResponseId":"' + self.lastResponseId + '"}'
-        else:
-            downloadRequestPayload = '{"format":"' + self.fileFormat + \
-                                     '","surveyId":"' + self.surveyId + '"}'
+            downloadRequestPayload['lastResponseId'] = self.lastResponseId
 
         downloadRequestResponse = requests.request("POST", downloadRequestUrl,
-                                                   data=downloadRequestPayload,
+                                                   data=json.dumps(downloadRequestPayload),
                                                    headers=headers)
 
         status_code = downloadRequestResponse.json()['meta']['httpStatus']
@@ -118,7 +118,7 @@ class QualtricsApi:
         df = pd.DataFrame(data['responses'])
         # replace np.nan with None so sql insertions don't insert 'nan' strings
         df = df.where(pd.notnull(df), None)
-        # os.remove(file_name)
+        os.remove(file_name)
         df_n_rows = df.shape[0]
         # if number of rows more than zero
         if df_n_rows > 0:


### PR DESCRIPTION
Currently there are only a few fields available when ClassificationResults.xlsx is generated.  User needed to add fields back to make the spreadsheet more useful for later processing.  By allowing users to specify which fields are needed to be included, it will save them a lot of time.

## Additions:
- Added a `FIELDS` list in the `utils/config.py` to specify the fields needed

## Changes:
- Merged data pulled from Qualtrics and data created during predictions to create a larger dataframe that give out needed columns
- Changed how we prepare for the JSON in `downloadRequestPayload` by using `json.dumps` to prevent incorrect string creation

## Removals:
- Removed unnecessary instructions in README.md

## Tests:
- Manual testing to make sure the fields are all available and nothing is breaking
- There's no automated tests at this moment, as this code do need to be refactored to be more testable.
- Tests definitely are needed, but refactoring is necessary to achieve that
