### PR TITLE
Add timestamp back to output file

### DIFF
--- a/HSM/app.py
+++ b/HSM/app.py
@@ -37,13 +37,13 @@ def make_predictions(df):
     '''
 
     mp = predict.MakePredictions(df, survey_type='sw')
-    results_path, df, id_pred_map = mp.predict()
+    results_path, df, id_pred_map, outfile = mp.predict()
 
-    return results_path, df, id_pred_map
+    return results_path, df, id_pred_map, outfile
 
 
-def user_prompt():
-    print("Done making predictions. You can find the results in ClassificationResults.xlsx")
+def user_prompt(outfile):
+    print("Done making predictions. You can find the results in {}".format(outfile))
     print('-'*80)
     print("Take a moment to review the predictions.")
     print("Change those that you disagree with.")
@@ -110,8 +110,8 @@ def main(survey_name="Site-Wide Survey English", model_description="model_sw.pkl
     db.dal.connect()
     session = db.dal.Session()
     df = get_survey_data(session)
-    results_path, df, id_pred_map = make_predictions(df)
-    user_prompt()
+    results_path, df, id_pred_map, outfile = make_predictions(df)
+    user_prompt(outfile)
     validated_id_pred_map = get_validations(results_path)
 
     insert_data(df, validated_id_pred_map, id_pred_map, survey_name, model_description, session)

--- a/HSM/model/predict.py
+++ b/HSM/model/predict.py
@@ -1,8 +1,9 @@
 import os
 import pandas as pd
 import dill as pickle
+from datetime import datetime
 from model.train import TrainClassifier
-from utils.config import FIELDS
+from utils.config import FIELDS, survey_id
 
 
 class MakePredictions():
@@ -79,7 +80,8 @@ class MakePredictions():
         results_dir = os.path.join(os.getcwd(), 'model', 'results')
         if not os.path.exists(results_dir):
             os.makedirs(os.path.join(results_dir))
-        results_path = os.path.join(results_dir, 'ClassificationResults.xlsx')
+        outfile = 'ClassificationResults_{}_{}.xlsx'.format(survey_id, datetime.now().strftime('%Y%m%d-%H%M%S'))
+        results_path = os.path.join(results_dir, outfile)
         writer = pd.ExcelWriter(results_path)
         # labeled_data_df.to_excel(writer, 'Classification Results', index=False)
         joined_df.to_excel(writer, 'Classification Results', index=False)
@@ -88,4 +90,4 @@ class MakePredictions():
                                labeled_data_df['SPAM']))
         df = self.df.drop(labels=['Normalized Comments'], axis=1)
 
-        return results_path, df, id_pred_map
+        return results_path, df, id_pred_map, outfile


### PR DESCRIPTION
Currently the output file ClassificationResults.xlsx can be overwritten every time we run app.py.  To prevent this from happening, a timestamp and survey ID are added to the file name, so each file will be uniquely named.  This work took some of the work that was done in #72.

## Additions:
- A timestamp in this format %Y%m%d-%H%M%S (i.e. 2019-04-11 05:13:35, will be 20190411-051335) is attached to the output file + the survey ID in front of the time stamp.

## Tests:
- Manually ran app.py to make sure the file is created with timestamp without any problems.
