### PR TITLE
Close the loop to retrain model every time

### DIFF
--- a/HSM/app.py
+++ b/HSM/app.py
@@ -1,7 +1,8 @@
+import time
+from argparse import ArgumentParser
 import pandas as pd
 from utils import qualtrics, validate, db, db_utils
 from model import predict, train
-import time
 
 
 def get_survey_data(session):
@@ -53,7 +54,7 @@ def user_prompt(outfile):
     user_input = ''
     while user_input != 'y':
         user_input = str(input("If you've finished reviewing the predictions, enter 'y': "))
-    print("Inserting data into database. Hold on...")
+    print("Inserting data into database. It may take a while.  Hold on...")
 
 
 def get_validations(results_path):
@@ -65,7 +66,7 @@ def get_validations(results_path):
         results_path (str): abs path to the results, ClassificationResults.xlsx
 
     Returns:
-        validated_id_pred_map (dict): a dict mapping Qualtrics ResponseIDs to the user-validated SPAM preditions
+        validated_id_pred_map (dict): a dict mapping Qualtrics ResponseIDs to the user-validated SPAM predictions
     '''
     v = validate.Validate(results_path)
     validated_id_pred_map = v.get_validations()
@@ -90,21 +91,9 @@ def insert_data(df, validated_id_pred_map, id_pred_map, survey_name, model_descr
     respondent_attributes = [x.replace(" ", "_") for x in df.columns
                              if x not in survey_questions]
     df['prediction'] = df['ResponseID'].map(id_pred_map)
-    print('*'*80)
-    print('id_pred_map')
-    print(id_pred_map)
     df['validated prediction'] = df['ResponseID'].map(validated_id_pred_map)
-    print('*'*80)
-    print('validated_id_pred_map')
-    print(validated_id_pred_map)
     prediction_set = set(df['prediction'])
-    print('*'*80)
-    print('prediction_set')
-    print(prediction_set)
     validation_set = set(df['validated prediction'])
-    print('*'*80)
-    print('validation_set')
-    print(validation_set)
     db_utils.survey_exists(survey_name, survey_questions, session)
     db_utils.model_exists(model_description, session)
     db_utils.validation_exists(validation_set, session)
@@ -115,20 +104,12 @@ def insert_data(df, validated_id_pred_map, id_pred_map, survey_name, model_descr
 
 def retrain_model(session):
     # Find the id of the comments_concatentated row
-    question_id = session.query(db.Question).filter(db.Question.text=="Comments_Concatenated").one().id
-    # comment_spam = session.query(db.Response, db.Validation, db.Respondent) \
-    #                         .filter(db.Response.question_id==question_id) \
-    #                         .filter(db.Response.respondent_id==db.Respondent.id) \
-    #                         .filter(db.Validation.id==db.Response.validation_id).count()
+    question_id = session.query(db.Question).filter(db.Question.text == "Comments_Concatenated").one().id
     comment_spam = session.query(db.Response.text, db.Validation.validation) \
-                            .filter(db.Response.question_id==question_id) \
-                            .filter(db.Response.respondent_id==db.Respondent.id) \
-                            .filter(db.Validation.id==db.Response.validation_id).all()
-    # comment_spam = session.query(db.Response.text, db.Respondent.SPAM) \
-    #                     .filter(db.Response.respondent_id==db.Respondent.id) \
-    #                     .filter(db.Response.question_id==question_id) \
-    #                     .all()
-    df_comment_spam = pd.DataFrame(comment_spam, columns =['Comments Concatenated', 'SPAM'])
+                          .filter(db.Response.question_id == question_id) \
+                          .filter(db.Response.respondent_id == db.Respondent.id) \
+                          .filter(db.Validation.id == db.Response.validation_id).all()
+    df_comment_spam = pd.DataFrame(comment_spam, columns=['Comments Concatenated', 'SPAM'])
     train.main(df_comment_spam)
 
 
@@ -155,4 +136,17 @@ def main(survey_name="Site-Wide Survey English", model_description="model_sw.pkl
 
 
 if __name__ == '__main__':
-    main()
+
+    program_desc = '''This application will get survey data from Qualtrics and make prediction on the data.
+                      It will then retrain the model based on the validated data.'''
+
+    parser = ArgumentParser(description=program_desc)
+    parser.add_argument("-s", "--survey_name", dest="survey_name",
+                        help="specify survey name to use", default="Site-Wide Survey English")
+    parser.add_argument("-m", "--model",
+                        default="model_sw.pkl",
+                        help="specify model file name")
+
+    args = parser.parse_args()
+
+    main(survey_name=args.survey_name, model_description=args.model)

--- a/HSM/model/predict.py
+++ b/HSM/model/predict.py
@@ -72,8 +72,8 @@ class MakePredictions():
             print(invalid_fields)
             print("Skipping them in the output...")
 
-        # Only pick out what the user wants to output
-        joined_df = joined_df[valid_fields]
+        # Only pick out what the user wants to output + the Decision Boundary Distance
+        joined_df = joined_df[valid_fields + ["Decision Boundary Distance"]]
         print("Here is the final list of the valid user-choosen fields in the config.py file we are using.")
         print(list(valid_fields))
 

--- a/HSM/model/train.py
+++ b/HSM/model/train.py
@@ -211,7 +211,6 @@ class TrainClassifier():
         lemmas_str = " ".join(lemma for lemma in lemmas)
         return lemmas_str
 
-
     def prepare_train(self):
         if self.train_df is None:
             labeled_data_path = os.path.join('model',
@@ -339,7 +338,8 @@ class TrainClassifier():
 def main(train_df=None):
     tc = TrainClassifier(train_df=train_df)
     train_df = tc.prepare_train()
-    results = tc.randomized_grid_search(train_df)
+    # Right now randomized_grid_search returns results, but not being used here
+    tc.randomized_grid_search(train_df)
 
 
 if __name__ == '__main__':

--- a/HSM/model/train.py
+++ b/HSM/model/train.py
@@ -58,10 +58,13 @@ class TrainClassifier():
         metric (str): the classifier scoring metric to use. Choose from:
         accuracy, roc_auc, avg_precision, fbeta, or recall. Note that for fbeta,
         beta = 2.
+        train_df (DataFrame): Training dataframe with 2 columns (Comments Concatenated, SPAM)
+        Default is None
     """
 
-    def __init__(self, metric='avg_precision'):
+    def __init__(self, metric='avg_precision', train_df=None):
         self.metric = metric
+        self.train_df = train_df
 
     @staticmethod
     def clean(doc):
@@ -208,12 +211,16 @@ class TrainClassifier():
         lemmas_str = " ".join(lemma for lemma in lemmas)
         return lemmas_str
 
-    def prepare_train(self):
-        labeled_data_path = os.path.join('model',
-                                         'training_data',
-                                         'training-sw.xlsx')
 
-        train_df = pd.read_excel(labeled_data_path)
+    def prepare_train(self):
+        if self.train_df is None:
+            labeled_data_path = os.path.join('model',
+                                             'training_data',
+                                             'training-sw.xlsx')
+
+            train_df = pd.read_excel(labeled_data_path)
+        else:
+            train_df = self.train_df
         print("\tNormalizing the text...")
         # normalize the comments, preparing for tf-idf
         train_df['Normalized Comments'] = train_df['Comments Concatenated'].astype(str).apply(
@@ -329,7 +336,11 @@ class TrainClassifier():
         return results
 
 
-if __name__ == '__main__':
-    tc = TrainClassifier()
+def main(train_df=None):
+    tc = TrainClassifier(train_df=train_df)
     train_df = tc.prepare_train()
     results = tc.randomized_grid_search(train_df)
+
+
+if __name__ == '__main__':
+    main()

--- a/HSM/model/train.py
+++ b/HSM/model/train.py
@@ -327,7 +327,7 @@ class TrainClassifier():
                        'roc_auc', 'auc', 'fbeta', 'recalls', 'best_score', 'best_estimator', 'y_test']
         results = {k: v for k, v in zip(result_keys, result_values)}
         if pickle_best:
-            pickle_dir = os.path.join(os.getcwd(), 'model', 'best_estimators')
+            pickle_dir = os.path.join(os.getcwd(), 'HSM', 'model', 'best_estimators')
             if not os.path.exists(pickle_dir):
                 os.makedirs(pickle_dir)
             pickle_path = os.path.join(pickle_dir, 'model_sw.pkl')

--- a/HSM/utils/db_utils.py
+++ b/HSM/utils/db_utils.py
@@ -1,7 +1,18 @@
 import pandas as pd
 from utils.config import SQLALCHEMY_URI
 from sqlalchemy_utils import database_exists, create_database
-from utils.db import Survey, Question, SurveyQuestion, Respondent, Response, Model, Version, Prediction, Validation, VersionPrediction
+from utils.db import (
+    Survey,
+    Question,
+    SurveyQuestion,
+    Respondent,
+    Response,
+    Model,
+    Version,
+    Prediction,
+    Validation,
+    VersionPrediction
+)
 from sqlalchemy import desc, func,  create_engine
 
 
@@ -13,23 +24,11 @@ def create_postgres_db():
 
 
 def survey_exists(survey_name, survey_questions, session):
-    print('*'*80)
-    print('survey_exists')
-    print('survey_name')
-    print(survey_name)
-    print('survey_questions')
-    print(survey_questions)
-    print('session')
-    print(session)
-
     survey_names = []
     for row in session.query(Survey.name).all():
         survey_names.append(row.name)
 
-    print('survey_names')
-    print(survey_names)
     if survey_name in survey_names:
-        print('survey_name in survey_names')
         pass
     else:
         site_wide = Survey(name="Site-Wide Survey English")
@@ -41,30 +40,15 @@ def survey_exists(survey_name, survey_questions, session):
 
 
 def model_exists(model_description, session):
-    print('*'*80)
-    print('model_exists')
-    print('model_description')
-    print(model_description)
-    print('session')
-    print(session)
     model_description = model_description.replace(".pkl", "")
-    print('change model_description')
-    print(model_description)
     version_description = model_description.rsplit('_', 1)[-1]
-    print('change version_description')
-    print(version_description)
     model_description = model_description.replace("_" + version_description, "")
-    print('change model_description')
-    print(model_description)
     version = Version(description=version_description)
     model_descriptions = []
     # TODO: Why are we doing this instead of querying the database directly for the row.description match?)
     for row in session.query(Model.description).all():
         model_descriptions.append(row.description)
-    print('model_descriptions')
-    print(model_descriptions)
     if model_description in model_descriptions:
-        print('model_description in model_descriptions')
         pass
     else:
         model = Model(description=model_description)
@@ -73,63 +57,32 @@ def model_exists(model_description, session):
 
 
 def validation_exists(validation_set, session):
-    print('*'*80)
-    print('validation_set')
-    print(validation_set)
-    print('session')
-    print(session)
     validations = []
     for row in session.query(Validation.validation).all():
         validations.append(row.validation)
-    print('validations')
-    print(validations)
     diff = validation_set.difference(set(validations))
-    print('diff')
-    print(diff)
     if len(diff) > 0:
         validations_to_insert = []
         for v in diff:
             validation = Validation(validation=int(v))
             validations_to_insert.append(validation)
-        print('validations_to_insert')
-        print(validations_to_insert)
         session.add_all(validations_to_insert)
 
 
 def prediction_exists(prediction_set, session):
-    print('*'*80)
-    print('prediction_exists')
-    print('prediction_set')
-    print(prediction_set)
-    print('session')
-    print(session)
     predictions = []
     for row in session.query(Prediction.prediction).all():
         predictions.append(row.prediction)
-    print('predictions')
-    print(predictions)
     diff = prediction_set.difference(set(predictions))
-    print('diff')
-    print(diff)
     if len(diff) > 0:
         predictions_to_insert = []
         for v in diff:
             prediction = Prediction(prediction=int(v))
             predictions_to_insert.append(prediction)
-        print('predictions_to_insert')
-        print(predictions_to_insert)
         session.add_all(predictions_to_insert)
 
 
 def insert_respondents(df, respondent_attributes, session):
-    print('*'*80)
-    print('insert_respondents')
-    print('df')
-    print(df)
-    print('respondent_attributes')
-    print(respondent_attributes)
-    print('session')
-    print(session)
     # Get the number of rows here
     for i in range(df.shape[0]):
         if (i % 1000) == 0:
@@ -172,8 +125,6 @@ def insert_responses(df, survey_questions, survey_name, model_description, sessi
 
         return prediction_id
 
-    print('*'*80)
-    print('insert_responses')
     survey_id = fetch_survey_id(survey_name, session)
     model_id, version_id = fetch_model_version_ids(model_description, session)
 
@@ -183,14 +134,12 @@ def insert_responses(df, survey_questions, survey_name, model_description, sessi
             session.commit()
             session.flush()
         data = df.iloc[i][survey_questions+['ResponseID', 'prediction', 'validated prediction']]
-        # print('data')
-        # print(data.encode('utf-8').strip())
         respondent_id = fetch_respondent_id(data['ResponseID'], session)
         validation = int(data['validated prediction'])
         validation_id = fetch_validation_id(validation, session)
         pred = int(data['prediction'])
         prediction_id = fetch_prediction_id(pred, session)
-        prediction = session.query(Prediction).get(prediction_id)
+        # prediction = session.query(Prediction).get(prediction_id)
         val = session.query(Validation).get(validation_id)
         for q in survey_questions:
             question_id = fetch_question_id(q, session)
@@ -199,35 +148,16 @@ def insert_responses(df, survey_questions, survey_name, model_description, sessi
                                 respondent_id=respondent_id,
                                 text=data[q])
 
-            # print("inside survey_questions loop")
-            # print('Response object')
-            # print('survey_id')
-            # print(survey_id)
-            # print('question_id')
-            # print(question_id)
-            # print('respondent_id')
-            # print(respondent_id)
-            # print('text')
-            # print(data[q].encode('utf-8'))
             val.responses.append(response)
             session.add(response)
             # By flushing we can get the response ID
             session.flush()
             response_id = response.id
             version_prediction = VersionPrediction()
-            # print('Creating Version Prediction')
             version_prediction.model_id = model_id
-            # print('model_id')
-            # print(model_id)
             version_prediction.version_id = version_id
-            # print('version_id')
-            # print(version_id)
             version_prediction.prediction_id = prediction_id
-            # print('prediction_id')
-            # print(prediction_id)
             version_prediction.response_id = response_id
-            # print('response_id')
-            # print(response_id)
             # version_prediction.prediction = prediction
             session.add(version_prediction)
         session.commit()

--- a/HSM/utils/db_utils.py
+++ b/HSM/utils/db_utils.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from utils.config import SQLALCHEMY_URI
 from sqlalchemy_utils import database_exists, create_database
-from utils.db import Survey, Question, SurveyQuestion, Respondent, Response, Model, Version, Prediction, Validation
+from utils.db import Survey, Question, SurveyQuestion, Respondent, Response, Model, Version, Prediction, Validation, VersionPrediction
 from sqlalchemy import desc, func,  create_engine
 
 
@@ -13,11 +13,23 @@ def create_postgres_db():
 
 
 def survey_exists(survey_name, survey_questions, session):
+    print('*'*80)
+    print('survey_exists')
+    print('survey_name')
+    print(survey_name)
+    print('survey_questions')
+    print(survey_questions)
+    print('session')
+    print(session)
+
     survey_names = []
     for row in session.query(Survey.name).all():
         survey_names.append(row.name)
 
+    print('survey_names')
+    print(survey_names)
     if survey_name in survey_names:
+        print('survey_name in survey_names')
         pass
     else:
         site_wide = Survey(name="Site-Wide Survey English")
@@ -29,14 +41,30 @@ def survey_exists(survey_name, survey_questions, session):
 
 
 def model_exists(model_description, session):
+    print('*'*80)
+    print('model_exists')
+    print('model_description')
+    print(model_description)
+    print('session')
+    print(session)
     model_description = model_description.replace(".pkl", "")
+    print('change model_description')
+    print(model_description)
     version_description = model_description.rsplit('_', 1)[-1]
+    print('change version_description')
+    print(version_description)
     model_description = model_description.replace("_" + version_description, "")
+    print('change model_description')
+    print(model_description)
     version = Version(description=version_description)
     model_descriptions = []
+    # TODO: Why are we doing this instead of querying the database directly for the row.description match?)
     for row in session.query(Model.description).all():
         model_descriptions.append(row.description)
+    print('model_descriptions')
+    print(model_descriptions)
     if model_description in model_descriptions:
+        print('model_description in model_descriptions')
         pass
     else:
         model = Model(description=model_description)
@@ -45,32 +73,64 @@ def model_exists(model_description, session):
 
 
 def validation_exists(validation_set, session):
+    print('*'*80)
+    print('validation_set')
+    print(validation_set)
+    print('session')
+    print(session)
     validations = []
     for row in session.query(Validation.validation).all():
         validations.append(row.validation)
+    print('validations')
+    print(validations)
     diff = validation_set.difference(set(validations))
+    print('diff')
+    print(diff)
     if len(diff) > 0:
         validations_to_insert = []
         for v in diff:
             validation = Validation(validation=int(v))
             validations_to_insert.append(validation)
+        print('validations_to_insert')
+        print(validations_to_insert)
         session.add_all(validations_to_insert)
 
 
 def prediction_exists(prediction_set, session):
+    print('*'*80)
+    print('prediction_exists')
+    print('prediction_set')
+    print(prediction_set)
+    print('session')
+    print(session)
     predictions = []
     for row in session.query(Prediction.prediction).all():
         predictions.append(row.prediction)
+    print('predictions')
+    print(predictions)
     diff = prediction_set.difference(set(predictions))
+    print('diff')
+    print(diff)
     if len(diff) > 0:
         predictions_to_insert = []
         for v in diff:
             prediction = Prediction(prediction=int(v))
             predictions_to_insert.append(prediction)
+        print('predictions_to_insert')
+        print(predictions_to_insert)
         session.add_all(predictions_to_insert)
 
 
 def insert_respondents(df, respondent_attributes, session):
+    print('*'*80)
+    print('insert_respondents')
+    print('df')
+    print(df)
+    print('respondent_attributes')
+    print(respondent_attributes)
+    print('session')
+    print(session)
+    # Get the number of rows here
     for i in range(df.shape[0]):
         if (i % 1000) == 0:
             session.commit()
@@ -112,6 +172,8 @@ def insert_responses(df, survey_questions, survey_name, model_description, sessi
 
         return prediction_id
 
+    print('*'*80)
+    print('insert_responses')
     survey_id = fetch_survey_id(survey_name, session)
     model_id, version_id = fetch_model_version_ids(model_description, session)
 
@@ -121,29 +183,53 @@ def insert_responses(df, survey_questions, survey_name, model_description, sessi
             session.commit()
             session.flush()
         data = df.iloc[i][survey_questions+['ResponseID', 'prediction', 'validated prediction']]
+        # print('data')
+        # print(data.encode('utf-8').strip())
         respondent_id = fetch_respondent_id(data['ResponseID'], session)
-        # validation = int(data['validated prediction'])
-        # validation_id = fetch_validation_id(validation, session)
-        # pred = int(data['prediction'])
-        # prediction_id = fetch_prediction_id(pred, session)
-        # prediction = session.query(Prediction).get(prediction_id)
-        # val = session.query(Validation).get(validation_id)
+        validation = int(data['validated prediction'])
+        validation_id = fetch_validation_id(validation, session)
+        pred = int(data['prediction'])
+        prediction_id = fetch_prediction_id(pred, session)
+        prediction = session.query(Prediction).get(prediction_id)
+        val = session.query(Validation).get(validation_id)
         for q in survey_questions:
             question_id = fetch_question_id(q, session)
             response = Response(survey_id=survey_id,
                                 question_id=question_id,
                                 respondent_id=respondent_id,
                                 text=data[q])
-            # val.responses.append(response)
+
+            # print("inside survey_questions loop")
+            # print('Response object')
+            # print('survey_id')
+            # print(survey_id)
+            # print('question_id')
+            # print(question_id)
+            # print('respondent_id')
+            # print(respondent_id)
+            # print('text')
+            # print(data[q].encode('utf-8'))
+            val.responses.append(response)
             session.add(response)
-            # response_id = response.id
-            # version_prediction = VersionPrediction()
-            # version_prediction.model_id = model_id
-            # version_prediction.version_id = version_id
-            # version_prediction.prediction_id = prediction_id
-            # version_prediction.response_id = response_id
+            # By flushing we can get the response ID
+            session.flush()
+            response_id = response.id
+            version_prediction = VersionPrediction()
+            # print('Creating Version Prediction')
+            version_prediction.model_id = model_id
+            # print('model_id')
+            # print(model_id)
+            version_prediction.version_id = version_id
+            # print('version_id')
+            # print(version_id)
+            version_prediction.prediction_id = prediction_id
+            # print('prediction_id')
+            # print(prediction_id)
+            version_prediction.response_id = response_id
+            # print('response_id')
+            # print(response_id)
             # version_prediction.prediction = prediction
-            # session.add(version_prediction)
+            session.add(version_prediction)
         session.commit()
 
 


### PR DESCRIPTION
Currently we use the same model to do prediction.  Even when validation shows up with incorrect prediction, there's no direct way to train the model with these corrections.  In order to complete the prediction->validation->train loop, we need to do a few things first:
- Recreate the data from the start, including prediction and validation
- Check that all data are created in the database (the prediction/validation were not saved in the database before)
- Pull out all data to use for training the model
- Put the model in the right place
- Dump database so it can be reused by other team members, this will help recreate the same model based on the data

In this PR, there are only a portion of what has been done to get the new model.  Other supporting documents and dump are saved in shared folder.

## Additions
- Added function to retrain the model by creating a dataframe from all data saved in the database
- Added command line argument parsers as we need to feed in arguments

## Changes
- Uncommented out some of the database utility code that saves prediction/validation data within inserting response
- Corrected path to place the model
- Added decision boundary function back in to spreadsheet for priority purposes

## Notes
- There are some significant performance issues arise after we uncommented out the code to save prediction/validation data.  Inserting response takes very long.  One record of spreadsheet data takes about 4 seconds to insert all the response and its corresponding relationships.  It may not be very bad if we have small amount of data, but it is significant when we have more data.  The issue has not been understood yet on what has caused it.  It can be the result of using ORM.  But this definitely needs to be resolved for user to use this tool.

## Tests
- There's no automated tests here, just manually testing and spot checking by running app.py.  This needs to start very soon as we continue to add more code.