### PR TITLE
Change Database Schema to a simpler schema

### DIFF
--- a/HSM/README.MD
+++ b/HSM/README.MD
@@ -66,7 +66,7 @@ There are times we need to load data in the database.  `load_data.py` will help 
 
 To use `load_data.py`, you can specify the path to the spreadsheet file that contains all the data.  The data will include two fields that represent the `filter_feature` and `validation`.
 - `filter_feature` - This value is the filter feature that is used to run prediction on.  In this specific case, it is the `'Comments Concatenated'` field.
-- `validation` - This value is the validation that started as a prediction and subject matter expert verified and correct any mistake.  In this specific case, it is the `'Validation'`.
+- `validation` - This value is the validation that started as a prediction and subject matter expert verified and corrected any mistake.  In this specific case, it is the `'Validation'`.
 
 To run `load_data.py`, type in the following commands in the terminal (this assumes you have `docker_compose up` running):
 ```bash

--- a/HSM/README.MD
+++ b/HSM/README.MD
@@ -61,6 +61,19 @@ Now that you're environment is set up, you can use `app.py` as a CLI tool. Here'
  - Inserts the survey data along with model predictions and your validation into the database.
 
  
+## Load Data
+There are times we need to load data in the database.  `load_data.py` will help with this task.  This version assumes it either has no `data` and `support_data` tables defined, or there are no data in `data` and `support_data` tables.  If they do exist, those will need to be deleted before performing running `load_data.py`, else, there can be duplicated data, incorrect representation of the actual data.
+
+To use `load_data.py`, you can specify the path to the spreadsheet file that contains all the data.  The data will include two fields that represent the `filter_feature` and `validation`.
+- `filter_feature` - This value is the filter feature that is used to run prediction on.  In this specific case, it is the `'Comments Concatenated'` field.
+- `validation` - This value is the validation that started as a prediction and subject matter expert verified and correct any mistake.  In this specific case, it is the `'Validation'`.
+
+To run `load_data.py`, type in the following commands in the terminal (this assumes you have `docker_compose up` running):
+```bash
+docker exec --user hsm --workdir /home/hsm -it mlaas-web /bin/bash -c "cd HSM;python load_data.py <file>"
+```
+
+
 ## TODO
  - log performance of the models (based on the ground truth established by the validation)
  - include a training data table in the database. Move training data there and include support to insert validated samples there.

--- a/HSM/load_data.py
+++ b/HSM/load_data.py
@@ -42,8 +42,8 @@ def main(file):
 
 if __name__ == '__main__':
 
-    program_desc = '''This application will get the spreadsheet and pull out essential data to fill out 
-                      the database. It will populate the database in the `data` table.  It also put all 
+    program_desc = '''This application will get the spreadsheet and pull out essential data to fill out
+                      the database. It will populate the database in the `data` table.  It also put all
                       other data in the database as well in support_data table.'''
 
     parser = ArgumentParser(description=program_desc)

--- a/HSM/load_data.py
+++ b/HSM/load_data.py
@@ -33,11 +33,9 @@ def main(file):
         support_data_obj.data = data_obj
         support_data_obj.data_id = support_data_obj.data.id
         session.add(support_data_obj)
-        print(f'data: {data_obj.id}')
-        print(f'support_data: {support_data_obj.id}')
-        print(f'support_data.data: {support_data_obj.data.id}')
 
     session.commit()
+    print(f'Loaded {len(data)} records of data and support_data.')
 
 
 if __name__ == '__main__':

--- a/HSM/load_data.py
+++ b/HSM/load_data.py
@@ -1,0 +1,54 @@
+import json
+from argparse import ArgumentParser
+import pandas as pd
+from utils import db, db_utils
+from utils.db import Data, SupportData
+
+filter_feature = 'Comments Concatenated'
+validation = 'Validation'
+
+
+def main(file):
+    db_utils.create_postgres_db()
+    db.dal.connect()
+    session = db.dal.Session()
+
+    df = pd.read_excel(file)
+
+    data_columns = [filter_feature, validation]
+
+    data = df[data_columns]
+    support_data = json.loads(df[df.columns.difference(data_columns)].to_json(orient='records'))
+
+    for i in range(len(data)):
+
+        data_row = data.iloc[i]
+        support_data_row = support_data[i]
+
+        data_obj = Data(filter_feature=str(data_row[filter_feature]), validation=int(data_row[validation]))
+        session.add(data_obj)
+        session.flush()
+        support_data_obj = SupportData(support_data=support_data_row)
+        data_obj.support_data = support_data_obj
+        support_data_obj.data = data_obj
+        support_data_obj.data_id = support_data_obj.data.id
+        session.add(support_data_obj)
+        print(f'data: {data_obj.id}')
+        print(f'support_data: {support_data_obj.id}')
+        print(f'support_data.data: {support_data_obj.data.id}')
+
+    session.commit()
+
+
+if __name__ == '__main__':
+
+    program_desc = '''This application will get the spreadsheet and pull out essential data to fill out 
+                      the database. It will populate the database in the `data` table.  It also put all 
+                      other data in the database as well in support_data table.'''
+
+    parser = ArgumentParser(description=program_desc)
+    parser.add_argument("file", help="specify path to file")
+
+    args = parser.parse_args()
+
+    main(file=args.file)

--- a/HSM/utils/db.py
+++ b/HSM/utils/db.py
@@ -30,6 +30,7 @@ class Data(Base):
 
     support_data = relationship("SupportData", uselist=False, back_populates="data")
 
+
 class SupportData(Base):
     __tablename__ = 'support_data'
     id = Column(Integer, primary_key=True, index=True)
@@ -37,6 +38,7 @@ class SupportData(Base):
 
     data_id = Column(Integer, ForeignKey('data.id'), nullable=False)
     data = relationship("Data", back_populates="support_data")
+
 
 class Survey(Base):
     __tablename__ = 'survey'

--- a/HSM/utils/db.py
+++ b/HSM/utils/db.py
@@ -1,6 +1,6 @@
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, JSON, Integer, String, ForeignKey
 from sqlalchemy.orm import relationship, sessionmaker
 from utils.config import SQLALCHEMY_URI
 
@@ -14,13 +14,29 @@ class DataAccessLayer:
         self.conn_string = SQLALCHEMY_URI
 
     def connect(self):
-        self.engine = create_engine(self.conn_string)
+        self.engine = create_engine(self.conn_string, echo=True)
         Base.metadata.create_all(self.engine)
         self.Session = sessionmaker(bind=self.engine)
 
 
 dal = DataAccessLayer()
 
+
+class Data(Base):
+    __tablename__ = 'data'
+    id = Column(Integer, primary_key=True, index=True)
+    filter_feature = Column(String(10000), nullable=True)
+    validation = Column(Integer)
+
+    support_data = relationship("SupportData", uselist=False, back_populates="data")
+
+class SupportData(Base):
+    __tablename__ = 'support_data'
+    id = Column(Integer, primary_key=True, index=True)
+    support_data = Column(JSON)
+
+    data_id = Column(Integer, ForeignKey('data.id'), nullable=False)
+    data = relationship("Data", back_populates="support_data")
 
 class Survey(Base):
     __tablename__ = 'survey'


### PR DESCRIPTION
This is to complete #91.

Changing data schema to a simpler schema to allow flexibility on how the data looks like, which means we can use it for more than one use cases, and the tool can be more generalized.

## Additions
- Defined a new simpler database schema that only breaks out essential data and supporting data.  Essential data is the data that is necessary to peform prediction and training (`data`).  Supporting data is the rest of the data, which is now grouped together in a JSON field (`support_data`).  These data may be needed later.  Saving them will allow adding new fields as filter features if needed.
- Added script to allow loading already processed data into database

## Tests
- No automated tests are written, but manual tests have been done to make sure it can load data into the database without issues.