### PR TITLE
Generalize predict

### DIFF
--- a/HSM/model/predict.py
+++ b/HSM/model/predict.py
@@ -56,10 +56,7 @@ class MakePredictions():
         labeled_data_df = pd.DataFrame(X)
         labeled_data_df.columns = [FILTER_FEATURE]
         labeled_data_df[PREDICTION_FIELD_NAME] = preds
-        print("#### This is dec_func")
-        print(dec_func)
         labeled_data_df['Decision Boundary Distance'] = abs(dec_func)
-        print(labeled_data_df['Decision Boundary Distance'])
         for col in data_columns:
             labeled_data_df[col] = data_columns[col]
 

--- a/HSM/model/predict.py
+++ b/HSM/model/predict.py
@@ -3,7 +3,15 @@ import pandas as pd
 import dill as pickle
 from datetime import datetime
 from model.train import TrainClassifier
-from utils.config import FIELDS, survey_id
+from utils.config import (
+    ENTRY_ID,
+    FIELDS,
+    FIELDS_TO_INCLUDED_FOR_PROCESSED_DATA_MAPPING,
+    FILTER_FEATURE,
+    FILTER_FEATURE_FIELDS,
+    PREDICTION_FIELD_NAME,
+    survey_id,
+)
 
 
 class MakePredictions():
@@ -20,35 +28,40 @@ class MakePredictions():
 
     def prepare_data(self):
         df = self.df
-        # Because these types are python objects, they need to be converted.
-        other_purpose = df['Q5'].astype(str)
-        unable_complete = df['Q7'].astype(str)
-        value = df['Q6'].astype(str)
-        purpose = df['Q3'].astype(str)
-        comments_concatenated = other_purpose+" "+unable_complete+" "+value+" "+purpose
-        comments_original = "Q3: " + purpose + "\n Q5: " + other_purpose + "\n Q6: " + value + "\n Q7: " \
-            + unable_complete
+        comments_concatenated = ""
+        comments_original = ""
+
+        for field in FILTER_FEATURE_FIELDS:
+            # Because these types are python objects, they need to be converted.
+            value = df[field].astype(str)
+            comments_concatenated += value
+            comments_original += f'{field}: {value}\n'
         df['Comments_Concatenated'] = comments_concatenated.apply(lambda x: x.strip())
         df['Normalized Comments'] = df['Comments_Concatenated'].apply(TrainClassifier().get_lemmas)
         X = df['Normalized Comments']
-        response_ids = df['ResponseID']
-        dates = df['EndDate']
 
-        return X, response_ids, dates, comments_original
+        result_series = {s: df[FIELDS_TO_INCLUDED_FOR_PROCESSED_DATA_MAPPING[s]]
+                         for s in FIELDS_TO_INCLUDED_FOR_PROCESSED_DATA_MAPPING}
+
+        result_series['Original Survey Responses'] = comments_original
+
+        return X, result_series
 
     def predict(self):
         with open(self.model, 'rb') as f:
             pickled_model = pickle.load(f)
-        X, response_ids, dates, comments_original = self.prepare_data()
+        X, data_columns = self.prepare_data()
         preds = pickled_model.predict(X)
         dec_func = pickled_model.decision_function(X)
         labeled_data_df = pd.DataFrame(X)
-        labeled_data_df.columns = ['Comments Concatenated']
-        labeled_data_df['SPAM'] = preds
+        labeled_data_df.columns = [FILTER_FEATURE]
+        labeled_data_df[PREDICTION_FIELD_NAME] = preds
+        print("#### This is dec_func")
+        print(dec_func)
         labeled_data_df['Decision Boundary Distance'] = abs(dec_func)
-        labeled_data_df['ResponseID'] = response_ids
-        labeled_data_df['Date'] = dates
-        labeled_data_df['Original Survey Responses'] = comments_original
+        print(labeled_data_df['Decision Boundary Distance'])
+        for col in data_columns:
+            labeled_data_df[col] = data_columns[col]
 
         print("Combining all specified columns and prediction...")
         print("Here's the list of available items to choose from the raw data:")
@@ -56,12 +69,13 @@ class MakePredictions():
         print("Here's the list of available items to choose from the processed prediction data:")
         print(list(labeled_data_df))
         # Using Outer Join to get all the data even if there's missing info on one side
-        joined_df = pd.merge(self.df, labeled_data_df, on='ResponseID', how='outer')
+        joined_df = pd.merge(self.df, labeled_data_df, on=ENTRY_ID, how='outer')
 
-        # There are two SPAM columns, SPAM_x and SPAM_y, SPAM_x should be removed becauses it is an empty column
-        # Need to rename SPAM_y to SPAM
-        joined_df = joined_df.drop(columns='SPAM_x')
-        joined_df = joined_df.rename(columns={'SPAM_y': 'SPAM'})
+        if PREDICTION_FIELD_NAME + '_x' in joined_df.columns:  # This means there are two SPAM columns
+            # There are two SPAM columns, SPAM_x and SPAM_y, SPAM_x should be removed because it is an empty column
+            # Need to rename SPAM_y to SPAM
+            joined_df = joined_df.drop(columns=PREDICTION_FIELD_NAME + '_x')
+            joined_df = joined_df.rename(columns={PREDICTION_FIELD_NAME + '_y': PREDICTION_FIELD_NAME})
 
         # Try to figure out what is valid columns
         valid_fields = [field for field in FIELDS if field in list(joined_df)]
@@ -77,17 +91,16 @@ class MakePredictions():
         print("Here is the final list of the valid user-choosen fields in the config.py file we are using.")
         print(list(valid_fields))
 
-        results_dir = os.path.join(os.getcwd(), 'model', 'results')
+        results_dir = os.path.join(os.getcwd(), 'HSM', 'model', 'results')
         if not os.path.exists(results_dir):
             os.makedirs(os.path.join(results_dir))
         outfile = 'ClassificationResults_{}_{}.xlsx'.format(survey_id, datetime.now().strftime('%Y%m%d-%H%M%S'))
         results_path = os.path.join(results_dir, outfile)
         writer = pd.ExcelWriter(results_path)
-        # labeled_data_df.to_excel(writer, 'Classification Results', index=False)
         joined_df.to_excel(writer, 'Classification Results', index=False)
         writer.save()
-        id_pred_map = dict(zip(labeled_data_df['ResponseID'],
-                               labeled_data_df['SPAM']))
+        id_pred_map = dict(zip(labeled_data_df[ENTRY_ID],
+                               labeled_data_df[PREDICTION_FIELD_NAME]))
         df = self.df.drop(labels=['Normalized Comments'], axis=1)
 
         return results_path, df, id_pred_map, outfile

--- a/HSM/model/predict.py
+++ b/HSM/model/predict.py
@@ -69,8 +69,14 @@ class MakePredictions():
         joined_df = pd.merge(self.df, labeled_data_df, on=ENTRY_ID, how='outer')
 
         if PREDICTION_FIELD_NAME + '_x' in joined_df.columns:  # This means there are two SPAM columns
-            # There are two SPAM columns, SPAM_x and SPAM_y, SPAM_x should be removed because it is an empty column
-            # Need to rename SPAM_y to SPAM
+            # There can be two columns for the prediction fields, one in df (which will have a suffix of _x),
+            # one in labeled_data_df (which will have a suffix of _y),
+            # and we will keep the one from labeled_data_df because it holds the actual prediction
+            # but this field needs to rename to with _y.
+            # i.e. SPAM is the field name and it appears in df and labeled_data_df, then we will have SPAM_x
+            # and SPAM_y column when joined in joined_df, right now assuming we are using SPAM_y because it
+            # holds the actual prediction, and SPAM_x should be removed because it came from the raw data.
+            # We also need to rename SPAM_y to SPAM
             joined_df = joined_df.drop(columns=PREDICTION_FIELD_NAME + '_x')
             joined_df = joined_df.rename(columns={PREDICTION_FIELD_NAME + '_y': PREDICTION_FIELD_NAME})
 

--- a/HSM/utils/config.py
+++ b/HSM/utils/config.py
@@ -76,6 +76,9 @@ FIELDS = [
 ]
 
 # DATA COLUMNS SETTINGS
+FILTER_FEATURE_FIELDS = ['Q5', 'Q7', 'Q6', 'Q3']
+FIELDS_TO_INCLUDED_FOR_PROCESSED_DATA_MAPPING = {'ResponseID': 'ResponseID', 'Date': 'EndDate'}
 FILTER_FEATURE = 'Comments Concatenated'
+PREDICTION_FIELD_NAME = 'SPAM'
 VALIDATION = 'Validation'
 ENTRY_ID = 'ResponseID'

--- a/HSM/utils/config.py
+++ b/HSM/utils/config.py
@@ -80,7 +80,9 @@ FIELDS = [
 # Fields are needed to do filter, they will be combined to be used for prediction and training
 FILTER_FEATURE_FIELDS = ['Q5', 'Q7', 'Q6', 'Q3']
 
-# Fielded from the raw spreadsheet to be included when processing data
+# Fielded from the raw spreadsheet to be included when processing data,
+# key is the field name we want to use for the processed data dataframe
+# value is the field name being used in the raw data
 FIELDS_TO_INCLUDED_FOR_PROCESSED_DATA_MAPPING = {'ResponseID': 'ResponseID', 'Date': 'EndDate'}
 
 # Field name that represents the filter feature

--- a/HSM/utils/config.py
+++ b/HSM/utils/config.py
@@ -76,9 +76,18 @@ FIELDS = [
 ]
 
 # DATA COLUMNS SETTINGS
+
+## Fields are needed to do filter, they will be combined to be used for prediction and training
 FILTER_FEATURE_FIELDS = ['Q5', 'Q7', 'Q6', 'Q3']
+
+## Fielded from the raw spreadsheet to be included when processing data
 FIELDS_TO_INCLUDED_FOR_PROCESSED_DATA_MAPPING = {'ResponseID': 'ResponseID', 'Date': 'EndDate'}
+
+## Field name that represents the filter feature
 FILTER_FEATURE = 'Comments Concatenated'
+
+## Field name to place the prediction/validation
 PREDICTION_FIELD_NAME = 'SPAM'
-VALIDATION = 'Validation'
+
+## Field name that identify each row in the raw spreadsheet
 ENTRY_ID = 'ResponseID'

--- a/HSM/utils/config.py
+++ b/HSM/utils/config.py
@@ -77,17 +77,17 @@ FIELDS = [
 
 # DATA COLUMNS SETTINGS
 
-## Fields are needed to do filter, they will be combined to be used for prediction and training
+# Fields are needed to do filter, they will be combined to be used for prediction and training
 FILTER_FEATURE_FIELDS = ['Q5', 'Q7', 'Q6', 'Q3']
 
-## Fielded from the raw spreadsheet to be included when processing data
+# Fielded from the raw spreadsheet to be included when processing data
 FIELDS_TO_INCLUDED_FOR_PROCESSED_DATA_MAPPING = {'ResponseID': 'ResponseID', 'Date': 'EndDate'}
 
-## Field name that represents the filter feature
+# Field name that represents the filter feature
 FILTER_FEATURE = 'Comments Concatenated'
 
-## Field name to place the prediction/validation
+# Field name to place the prediction/validation
 PREDICTION_FIELD_NAME = 'SPAM'
 
-## Field name that identify each row in the raw spreadsheet
+# Field name that identify each row in the raw spreadsheet
 ENTRY_ID = 'ResponseID'


### PR DESCRIPTION
This is to implement the generalization of `predict` for issue #98 

- Any reference to specific data columns are now abstracted away in the `config.py` file.

## Tests
- Manual tests were done to make sure the current dataset still works fine and generate the same `ClassificationResults` spreadsheet.
