### PR TITLE
Add instructions on cloud.gov setup for the database

### DIFF
--- a/HSM/README.MD
+++ b/HSM/README.MD
@@ -111,7 +111,7 @@ Now that your environment is set up, you can use `app.py` as a CLI tool. Here's 
 
 
 ## Cloud.gov Configuration
-This is Work In Progress instructions as they were only quickly tested out.  You will need to swap out `docker-compose.yml` to use the `docker-compose-cloud.yml` file first.  Save the current `docker-compose.yml` at a safe place that you can swap back out if necessary when you want to use database within Docker.  The following commands include moving `docker-compose.yml` to `docker-compose-local.yml`:
+These are work-in-progress instructions as they were only quickly tested out.  You will need to swap out `docker-compose.yml` to use the `docker-compose-cloud.yml` file first.  Save the current `docker-compose.yml` at a safe place that you can swap back out if necessary when you want to use database within Docker.  The following commands include moving `docker-compose.yml` to `docker-compose-local.yml`:
 ```bash
 mv docker-compose.yml docker-compose-local.yml
 mv docker-compose-cloud.yml docker-compose.yml
@@ -145,7 +145,7 @@ Name: <CLOUD_DB_NAME>
 Leave this terminal open while you want to use the SSH tunnel. Press Control-C to stop.
 ```
 
-Take the information in the `< >` above and modify the `.env` file accordingly.  You will have to keep this terminal window open throughtout the time you run the the tool.
+Take the information in the `< >` above and modify the `.env` file accordingly.  You will have to keep this terminal window open throughout the time you run the tool.
 
 If at any time, you are getting errors about the database access, you may have to exit out of this and rerun the `connect-to-service` command.
 

--- a/HSM/README.MD
+++ b/HSM/README.MD
@@ -30,7 +30,7 @@ First copy the template in `sample.env`.
 cp sample.env .env
 ```
 
-Modify environment variables to set up for the specific dataset in `.env`.  See details in `.env`.
+Modify environment variables to set up for the specific dataset in `.env`.  See details in `.env`.  If you want to store data on the cloud instead of using a local database and filesystem, see instructions on [Cloud.gov Configuration](cloud-gov-configuration).  This will allow you to have a database and filesystem on the cloud for sharing.
 
 Install Pipenv if it is not installed:
 ```bash
@@ -108,6 +108,49 @@ Now that your environment is set up, you can use `app.py` as a CLI tool. Here's 
     - Return to your terminal and enter `y` to tell the script to wake up and continue.
 
  - Inserts the survey data along with model predictions and your validation into the database.
+
+
+## Cloud.gov Configuration
+This is Work In Progress instructions as they were only quickly tested out.  You will need to swap out `docker-compose.yml` to use the `docker-compose-cloud.yml` file first.  Save the current `docker-compose.yml` at a safe place that you can swap back out if necessary when you want to use database within Docker.  The following commands include moving `docker-compose.yml` to `docker-compose-local.yml`:
+```bash
+mv docker-compose.yml docker-compose-local.yml
+mv docker-compose-cloud.yml docker-compose.yml
+```
+
+### Cloud.gov Database
+This tool makes use of a database to store all the dataset for the purposes of training the model, keeping all the available data to avoid downloading the same data from Qualtrics again.  In order to use a database on Cloud.gov, you will need to have an account on cloud.gov, and you will create an application with a Postgresql database service instance.  This service instance is also binded to the application you create.  Once that is set up, you will need to log into cloud.gov in your terminal:
+```bash
+cf login -a api.fr.cloud.gov --sso
+```
+
+You will need to target your organization and space where your application is in.  Then you will need to install [CF-Service-Connect](https://github.com/18F/cf-service-connect) if you haven't.  This will allow you to SSH tunnel into Cloud.gov environment so you will have access to your database.  Once installed, you will need to connect to the database by running the following command, and replacing those in the `< >`:
+```bash
+cf connect-to-service -no-client <cloud.gov app> <cloud.gov database binded to the app>
+```
+
+You will get an output that looks like this:
+```bash
+It will give you the following output, pull the corresponding information out as environment variables:
+Finding the service instance details...
+Setting up SSH tunnel...
+SSH tunnel created.
+Skipping call to client CLI. Connection information:
+
+Host: localhost
+Port: <CLOUD_DB_PORT>
+Username: <CLOUD_DB_USER>
+Password: <CLOUD_DB_PASS>
+Name: <CLOUD_DB_NAME>
+
+Leave this terminal open while you want to use the SSH tunnel. Press Control-C to stop.
+```
+
+Take the information in the `< >` above and modify the `.env` file accordingly.  You will have to keep this terminal window open throughtout the time you run the the tool.
+
+If at any time, you are getting errors about the database access, you may have to exit out of this and rerun the `connect-to-service` command.
+
+### Cloud.gov S3 Storage
+This part has not been tested out at all.  The storage is to store the machine learning model.  But you will do the same as you would set up the Cloud.gov database.  You will need to create a new S3 service instance, and bind it to an application.  This is the [detailed instructions on how to interact with S3 outside of Cloud.gov](https://cloud.gov/docs/services/s3/#interacting-with-your-s3-bucket-from-outside-cloud-gov). Code changes are necessary to get this implemented.
 
  
 ## Load Data

--- a/HSM/utils/config.py
+++ b/HSM/utils/config.py
@@ -13,18 +13,22 @@ users = {
 
 # DATABASE SETTINGS
 print(f'CLOUD_GOV:{os.getenv("CLOUD_GOV")}')
-if not os.getenv('CLOUD_GOV'):
-    DIALECT = "postgresql+psycopg2"
+DB_DIALECT = "postgresql+psycopg2"
+if not os.getenv('CLOUD_GOV') or os.getenv('CLOUD_GOV') == 'NO' :
     DB_USER = os.getenv('DB_USER')
     DB_PASS = os.getenv('DB_PASS')
     DB_ADDR = os.getenv('DB_ADDR')
     DB_NAME = os.getenv('DB_NAME')
 
-    SQLALCHEMY_URI = f"{DIALECT}://{DB_USER}:{DB_PASS}@{DB_ADDR}/{DB_NAME}"
+    SQLALCHEMY_URI = f"{DB_DIALECT}://{DB_USER}:{DB_PASS}@{DB_ADDR}/{DB_NAME}"
 else:  # CLOUD_GOV
-    SQLALCHEMY_URI = os.getenv('DATABASE_URL')
-    if "postgresql:" in SQLALCHEMY_URI:  # This means the dialect is not included
-        SQLALCHEMY_URI = SQLALCHEMY_URI.replace("postgresql:" "postgresql+psycopg2:", 1)
+    CLOUD_DB_USER = os.getenv('CLOUD_DB_USER')
+    CLOUD_DB_PASS = os.getenv('CLOUD_DB_PASS')
+    CLOUD_DB_ADDR = os.getenv('CLOUD_DB_ADDR')
+    CLOUD_DB_PORT = os.getenv('CLOUD_DB_PORT')
+    CLOUD_DB_NAME = os.getenv('CLOUD_DB_NAME')
+    SQLALCHEMY_URI = f"{DB_DIALECT}://{CLOUD_DB_USER}:{CLOUD_DB_PASS}@{CLOUD_DB_ADDR}:{CLOUD_DB_PORT}/{CLOUD_DB_NAME}"
+    print(f'SQLALCHEMY_URI: {SQLALCHEMY_URI}')
 
 
 # QUALTRICS API SETTINGS

--- a/HSM/utils/config.py
+++ b/HSM/utils/config.py
@@ -14,7 +14,7 @@ users = {
 # DATABASE SETTINGS
 print(f'CLOUD_GOV:{os.getenv("CLOUD_GOV")}')
 DB_DIALECT = "postgresql+psycopg2"
-if not os.getenv('CLOUD_GOV') or os.getenv('CLOUD_GOV') == 'NO' :
+if not os.getenv('CLOUD_GOV') or os.getenv('CLOUD_GOV') == 'NO':
     DB_USER = os.getenv('DB_USER')
     DB_PASS = os.getenv('DB_PASS')
     DB_ADDR = os.getenv('DB_ADDR')

--- a/docker-compose-cloud.yml
+++ b/docker-compose-cloud.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+    web:
+        build: .
+        tty: true
+        container_name: ${CONTAINER_NAME_WEB}
+        restart: always
+        ports:
+            - "${HOST_PORT}:${HOST_PORT}"
+        env_file:
+            - ./.env
+        volumes:
+            - .:/home/hsm
+        network_mode: "host"
+        entrypoint:
+            - ./docker-entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         container_name: ${CONTAINER_NAME_WEB}
         restart: always
         ports:
-            - "${HOST_PORT}:8080"
+            - "${HOST_PORT}:${HOST_PORT}"
         environment:
             - DB_NAME=${DB_NAME}
             - DB_ADDR=${DB_ADDR}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,4 +2,4 @@
 ROOT=/home/hsm/HSM
 
 cd $ROOT
-exec gunicorn -b :8080 --reload --access-logfile - --error-logfile - api:app
+exec gunicorn -b :$HOST_PORT --reload --access-logfile - --error-logfile - api:app

--- a/sample.env
+++ b/sample.env
@@ -48,3 +48,43 @@ ADMIN=CHANGE_TO_SOMETHING_SECRETIVE
 
 # This is the user password for API
 USER=CHANGE_TO_SOMETHING_SECRETIVE
+
+
+
+## CLOUD.GOV ENV VARS (Only needed when using API) ##
+# This indicates that if Cloud.gov is being used for database and file storage, YES means we are, NO means we are not
+# or if CLOUD_GOV environment variable is not here, we are not using Cloud.gov as well
+CLOUD_GOV=NO
+
+### CLOUD.GOV DATABASE SETTINGS ###
+# To obtain these data, you will need to do a SSH-Tunneling to the Cloud.gov database
+# Run `cf connect-to-service -no-client <cloud.gov app> <cloud.gov database binded to the app>` in a terminal
+# It will give you the following output, pull the corresponding information out as environment variables:
+# Finding the service instance details...
+# Setting up SSH tunnel...
+# SSH tunnel created.
+# Skipping call to client CLI. Connection information:
+
+# Host: localhost
+# Port: <CLOUD_DB_PORT>
+# Username: <CLOUD_DB_USER>
+# Password: <CLOUD_DB_PASS>
+# Name: <CLOUD_DB_NAME>
+
+# Leave this terminal open while you want to use the SSH tunnel. Press Control-C to stop.
+
+# Pull the data under `Username` above
+CLOUD_DB_USER=hsm
+
+# Pull the data under `Password` above
+CLOUD_DB_PASS=hsm
+
+# This information should not be changed, as we are using Docker to bring up our environment
+# This will figure out the host address correctly
+CLOUD_DB_ADDR=host.docker.internal
+
+# Pull the data under `Port` above, this variable changes every time you run the command above
+CLOUD_DB_PORT=5432
+
+# Pull the data under `Name` above
+CLOUD_DB_NAME=hsm-db


### PR DESCRIPTION
This is to complete https://github.com/18F/10x-MLaaS/issues/105.

This is documentation after exploring the use of cloud.gov database.  This is not the best solution for production because it requires a lot of human intervention when connection failed, and needed to restart.  It also requires someone with technical background to know what to do when the connection cannot be established.

## Additions
- Added instructions on how to use cloud.gov database by connecting directly with code
- Did not explore connecting with filesystem because priority is no longer as high but point to cloud.gov  instructions on how that can be done if necessary