### PR TITLE
119 Updated obsolete training parameter

### DIFF
--- a/HSM/model/train.py
+++ b/HSM/model/train.py
@@ -295,7 +295,7 @@ class TrainClassifier():
 
         random_search = RandomizedSearchCV(pipe, param_distributions=param_dist,
                                            scoring=scoring, refit=score,
-                                           n_iter=n_iter_search, cv=5, n_jobs=-1,
+                                           n_iter=n_iter_search, cv=5, n_jobs=1,
                                            verbose=1)
         random_search.fit(X_train, y_train)
         y_pred = random_search.predict(X_test)


### PR DESCRIPTION
Short description explaining the high-level reason for the pull request

## Reference
- https://github.com/18F/10x-MLaaS/issues/119

## Additions
- N/A

## Removals
- N/A

## Changes
- In calling `RandomizedSearchCV`, a method in the library `sklearn`, previous code specified the number of parallel jobs as `-1`; this causes errors in current versions of `sklearn`. That value has been updated to `1`.

## Testing
- Training now completes successfully. Some users may not have been experiencing issues with training; this would be because their environment's version of the library `sklearn` is old and has not incorporated the changes that broke the existing code.

## Review

- @user

## Notes

-

## Todos

-
